### PR TITLE
Add configuration for gtag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,11 @@ color        : "#f2acae"
 markdown_ext : "markdown,mkdown,mkdn,mkd,md,html"
 include      : [".well-known"]
 
+analytics:
+  gtag:
+    id:
+    anonymize_ip: # false (default)
+
 defaults:
   - values:
       layout: "default"

--- a/_includes/gtag.html
+++ b/_includes/gtag.html
@@ -1,0 +1,11 @@
+{% if site.analytics.gtag.id %}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics.gtag.id }}"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', '{{ site.analytics.gtag.id }}', { 'anonymize_ip': {{ site.analytics.gtag.anonymize_ip | default: false }}});
+</script>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,10 @@ layout: compress
 	{% include head.html %}
 </head>
 <body>
+{% if jekyll.environment == 'production' %}
+	{% include gtag.html %}
+{% endif %}
+
 	<div class="content">
 		{% include nav.html %}
 


### PR DESCRIPTION
This adds Google Analytics support.

This can be enabled by:
- setting JEKYLL_ENV=production environment variable, AND
- Adding the tracking ID to `site.analytics.gtag.id` in `_config.yml`